### PR TITLE
Add firefox bin installation for firefoxdriver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
       <version>5.4.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+            <groupId>org.rauschig</groupId>
+            <artifactId>jarchivelib</artifactId>
+            <version>0.7.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-            <groupId>org.rauschig</groupId>
-            <artifactId>jarchivelib</artifactId>
-            <version>0.7.1</version>
+      <groupId>org.rauschig</groupId>
+      <artifactId>jarchivelib</artifactId>
+      <version>0.7.1</version>
     </dependency>
   </dependencies>
 

--- a/src/functionaltest/java/com/ericsson/ei/config/SeleniumConfig.java
+++ b/src/functionaltest/java/com/ericsson/ei/config/SeleniumConfig.java
@@ -95,7 +95,7 @@ public class SeleniumConfig {
                 LOGGER.error("Failed to load properties");
                 return false;
             } else {
-                LOGGER.info("Properties have been loaded.");
+                LOGGER.debug("Properties have been loaded.");
                 return true;
             }
         } catch (NumberFormatException e) {

--- a/src/functionaltest/java/com/ericsson/ei/config/SeleniumConfig.java
+++ b/src/functionaltest/java/com/ericsson/ei/config/SeleniumConfig.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.firefox.FirefoxProfile;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Properties;
@@ -76,8 +77,7 @@ public class SeleniumConfig {
     }
 
     private static FirefoxBinary installFirefoxBinary() {
-        String[] firefoxBZip2FileUrlLinuxBits = firefoxBZip2FileUrlLinux.split("/");
-        String firefoxBZip2FileNameLinux = firefoxBZip2FileUrlLinuxBits[firefoxBZip2FileUrlLinuxBits.length-1];
+        String firefoxBZip2FileNameLinux = FilenameUtils.getName(firefoxBZip2FileUrlLinux);
 
         String firefoxBZip2FilePath = String.join(
                 File.separator, tempDownloadDirectory.getPath(), firefoxBZip2FileNameLinux);

--- a/src/functionaltest/java/com/ericsson/ei/config/SeleniumConfig.java
+++ b/src/functionaltest/java/com/ericsson/ei/config/SeleniumConfig.java
@@ -64,7 +64,7 @@ public class SeleniumConfig {
         } else if (SystemUtils.IS_OS_WINDOWS) {
             System.setProperty("webdriver.gecko.driver", "src/functionaltest/resources/geckodriver.exe");
         } else {
-            LOGGER.error("OS currently not supported.");
+            LOGGER.error(SystemUtils.OS_NAME + " currently not supported.");
             throw new OSNotSupportedException();
         }
 

--- a/src/functionaltest/java/com/ericsson/ei/config/Utils.java
+++ b/src/functionaltest/java/com/ericsson/ei/config/Utils.java
@@ -52,24 +52,19 @@ public class Utils {
         try (TarArchiveInputStream fileInput = new TarArchiveInputStream(
                 new BZip2CompressorInputStream(new FileInputStream(firefoxBZip2FilePath)))) {
             TarArchiveEntry entry;
-            try {
-                while ((entry = fileInput.getNextTarEntry()) != null) {
-                    if (entry.isDirectory()) {
-                        continue;
-                    }
-                    final File curfile = new File(destinationPath, entry.getName());
-                    final File parent = curfile.getParentFile();
-                    if (!parent.exists()) {
-                        parent.mkdirs();
-                    }
-                    final FileOutputStream fileOutput = new FileOutputStream(curfile);
-                    IOUtils.copy(fileInput, fileOutput);
-                    fileOutput.close();
+            while ((entry = fileInput.getNextTarEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
                 }
-            } catch (IOException e) {
-                LOGGER.error("IOException.\nError: {}", e.getMessage());
+                final File curfile = new File(destinationPath, entry.getName());
+                final File parent = curfile.getParentFile();
+                if (!parent.exists()) {
+                    parent.mkdirs();
+                }
+                final FileOutputStream fileOutput = new FileOutputStream(curfile);
+                IOUtils.copy(fileInput, fileOutput);
+                fileOutput.close();
             }
-            fileInput.close();
         } catch (FileNotFoundException e) {
             LOGGER.error("FileNotFoundException.\nError: {}", e.getMessage());
         } catch (IOException e) {

--- a/src/functionaltest/java/com/ericsson/ei/config/Utils.java
+++ b/src/functionaltest/java/com/ericsson/ei/config/Utils.java
@@ -1,0 +1,117 @@
+package com.ericsson.ei.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Utils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
+
+    /**
+     * Loads properties from file path.
+     *
+     * @param filePath
+     *            path to the properties file
+     * @return properties object
+     */
+    public static Properties getProperties(final String filePath) {
+        Properties properties = new Properties();
+        File file = new File(filePath);
+        try {
+            properties.load(new FileInputStream(file));
+        } catch (IOException e) {
+            LOGGER.error("Failed load properties from path.\nError: {}", e.getMessage());
+        }
+        return properties;
+    }
+
+    /**
+     * Extracts a BZip2 archive to a destination folder.
+     *
+     * @param firefoxTarballFilePath
+     *            string containing the firefox BZip2 filepath.
+     * @param destination
+     *            string containing a destination path.
+     */
+    public static void extractBZip2InDir(final String firefoxBZip2FilePath, String destinationPath) {
+        LOGGER.info("Extracting firefox BZip2 archive...");
+        try (TarArchiveInputStream fileInput = new TarArchiveInputStream(
+                new BZip2CompressorInputStream(new FileInputStream(firefoxBZip2FilePath)))) {
+            TarArchiveEntry entry;
+            try {
+                while ((entry = fileInput.getNextTarEntry()) != null) {
+                    if (entry.isDirectory()) {
+                        continue;
+                    }
+                    final File curfile = new File(destinationPath, entry.getName());
+                    final File parent = curfile.getParentFile();
+                    if (!parent.exists()) {
+                        parent.mkdirs();
+                    }
+                    final FileOutputStream fileOutput = new FileOutputStream(curfile);
+                    IOUtils.copy(fileInput, fileOutput);
+                    fileOutput.close();
+                }
+            } catch (IOException e) {
+                LOGGER.error("IOException.\nError: {}", e.getMessage());
+            }
+            fileInput.close();
+        } catch (FileNotFoundException e) {
+            LOGGER.error("FileNotFoundException.\nError: {}", e.getMessage());
+        } catch (IOException e) {
+            LOGGER.error("IOException.\nError: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Downloads a file from a given URL to a given destination path.
+     *
+     * @param url
+     *            string containing a URL.
+     * @param destination
+     *            string containing a destination path.
+     */
+    public static void downloadFileFromUrlToDestination(final String url, final String destination) {
+        final File file = new File(destination);
+        URL urlObj = null;
+
+        try {
+            urlObj = new URL(url);
+            LOGGER.info("Downloading file.\nSource: {}\nDestination: {}", url, destination);
+            FileUtils.copyURLToFile(urlObj, file);
+        } catch (MalformedURLException e) {
+            LOGGER.error("Failed to create URL object.\nURL: {}\nError: {}", url, e.getMessage());
+        } catch (IOException e) {
+            LOGGER.error("Failed to download file.\nURL: {}\nError: {}", url, e.getMessage());
+        }
+    }
+
+    /**
+     * Makes file executable in filesystem.
+     *
+     * @param binFile
+     *            file to make executable
+     */
+    public static void makeBinFileExecutable(final File binFile) {
+        if (binFile.isFile()) {
+            LOGGER.info("Changing bin file to be executable.\nPath: {}", binFile.getPath());
+            binFile.setExecutable(true);
+        } else {
+            LOGGER.error("Path is not a file.\nPath: {}", binFile.getPath());
+        }
+    }
+}

--- a/src/functionaltest/java/com/ericsson/ei/frontend/SeleniumBaseClass.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/SeleniumBaseClass.java
@@ -78,7 +78,7 @@ public class SeleniumBaseClass {
         }
     }
 
-    protected String getJSONStringFromFile(String filepath) throws IOException {
+    protected static String getJSONStringFromFile(String filepath) throws IOException {
         return new String(Files.readAllBytes(Paths.get(filepath)), StandardCharsets.UTF_8).replaceAll("[\\r\\n ]", "");
     }
 

--- a/src/functionaltest/java/com/ericsson/ei/frontend/SeleniumBaseClass.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/SeleniumBaseClass.java
@@ -57,7 +57,7 @@ public class SeleniumBaseClass {
         MockitoAnnotations.initMocks(this);
         webController.setFrontendServicePort(randomServerPort);
 
-        driver = SeleniumConfig.getFirefoxDriver();
+        driver = SeleniumConfig.initFirefoxDriver();
         baseUrl = SeleniumConfig.getBaseUrl(randomServerPort);
     }
 
@@ -72,7 +72,6 @@ public class SeleniumBaseClass {
         backendInstancesInformationWriter.write(default_instances_information);
         backendInstancesInformationWriter.close();
 
-        driver.quit();
         String verificationErrorString = verificationErrors.toString();
         if (!verificationErrorString.equals("")) {
             fail(verificationErrorString);

--- a/src/functionaltest/java/com/ericsson/ei/frontend/TestRulesFunctionality.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/TestRulesFunctionality.java
@@ -42,11 +42,11 @@ public class TestRulesFunctionality extends SeleniumBaseClass {
         new WebDriverWait(driver, 10).until((webdriver) -> testRulesPage.presenceOfTestRulesHeader());
 
         // Verify that "download rules template" button works
-        String mockedResponse = this.getJSONStringFromFile(RULES_TEMPLATE_FILE_PATH);
+        String mockedResponse = getJSONStringFromFile(RULES_TEMPLATE_FILE_PATH);
         new WebDriverWait(driver, 10).until((webdriver) -> testRulesPage.presenceOfClickDownloadRulesTemplateButton());
         testRulesPage.clickDownloadRulesTemplate(mockedResponse);
         new WebDriverWait(driver, 10).until((webdriver) -> Files.exists(Paths.get(DOWNLOADED_RULES_TEMPLATE_FILE_PATH)));
-        String downloadedRulesTemplate = this.getJSONStringFromFile(DOWNLOADED_RULES_TEMPLATE_FILE_PATH);
+        String downloadedRulesTemplate = getJSONStringFromFile(DOWNLOADED_RULES_TEMPLATE_FILE_PATH);
         assertEquals(mockedResponse, downloadedRulesTemplate);
 
         // Verify that uploading the downloaded template file works.
@@ -58,7 +58,7 @@ public class TestRulesFunctionality extends SeleniumBaseClass {
         // Verify that it is possible to download rules
         testRulesPage.clickDownloadRulesButton();
         new WebDriverWait(driver, 10).until((webdriver) -> Files.exists(Paths.get(DOWNLOADED_RULES_FILE_PATH)));
-        String downloadedRules = this.getJSONStringFromFile(DOWNLOADED_RULES_FILE_PATH);
+        String downloadedRules = getJSONStringFromFile(DOWNLOADED_RULES_FILE_PATH);
         assertEquals(downloadedRulesTemplate, downloadedRules);
 
         // Verify that add rule button works
@@ -70,10 +70,10 @@ public class TestRulesFunctionality extends SeleniumBaseClass {
         new WebDriverWait(driver, 10).until((webdriver) -> !testRulesPage.presenceOfRuleNumber(3));
 
         // Verify that "download events template" button works
-        String downloadEventsTemplateMockedResponse = this.getJSONStringFromFile(EVENTS_TEMPLATE_FILE_PATH);
+        String downloadEventsTemplateMockedResponse = getJSONStringFromFile(EVENTS_TEMPLATE_FILE_PATH);
         testRulesPage.clickDownloadEventsTemplate(downloadEventsTemplateMockedResponse);
         new WebDriverWait(driver, 10).until((webdriver) -> Files.exists(Paths.get(DOWNLOADED_EVENTS_TEMPLATE_FILE_PATH)));
-        String downloadedEventsTemplate = this.getJSONStringFromFile(DOWNLOADED_EVENTS_TEMPLATE_FILE_PATH);
+        String downloadedEventsTemplate = getJSONStringFromFile(DOWNLOADED_EVENTS_TEMPLATE_FILE_PATH);
         assertEquals(downloadEventsTemplateMockedResponse, downloadedEventsTemplate);
 
         // Verify that uploading the downloaded template file works.
@@ -91,7 +91,7 @@ public class TestRulesFunctionality extends SeleniumBaseClass {
         new WebDriverWait(driver, 10).until((webdriver) -> !testRulesPage.presenceOfEventNumber(3));
 
         // Verify that find aggregated object button works
-        String findAggregatedObjectResponse = this.getJSONStringFromFile(AGGREGATED_OBJECT_FILE_PATH);
+        String findAggregatedObjectResponse = getJSONStringFromFile(AGGREGATED_OBJECT_FILE_PATH);
         testRulesPage.clickFindAggregatedObject(findAggregatedObjectResponse);
         assertEquals(findAggregatedObjectResponse, testRulesPage.getAggregatedResultData());
     }

--- a/src/functionaltest/java/com/ericsson/ei/frontend/TestSwitchBackend.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/TestSwitchBackend.java
@@ -37,6 +37,7 @@ public class TestSwitchBackend extends SeleniumBaseClass{
         File.separator, "src", "functionaltest", "resources", "responses", "DefaultInstanceSubscriptionResponse.json");
     private static final String INFORMATION_RESPONSE_FILEPATH = String.join(
         File.separator, "src", "functionaltest", "resources", "responses", "InformationResponse.json");
+
     @Test
     public void testSwitchBackend() throws Exception {
         setUpMocks();
@@ -73,6 +74,16 @@ public class TestSwitchBackend extends SeleniumBaseClass{
         switchBackendPage.removeInstanceNumber(1);
         assertEquals("switchBackendPage.presenceOfInstance returned true when it should have been false",
             false, switchBackendPage.presenceOfInstance(1));
+
+        tearDownMocks();
+    }
+
+    private void tearDownMocks() {
+        mockServer1.stop();
+        mockServer2.stop();
+
+        mockClient1.stop();
+        mockClient2.stop();
     }
 
     private void setUpMocks() throws IOException {

--- a/src/functionaltest/java/com/ericsson/ei/frontend/TestSwitchBackend.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/TestSwitchBackend.java
@@ -21,10 +21,10 @@ import com.ericsson.ei.frontend.pageobjects.SubscriptionPage;
 import com.ericsson.ei.frontend.pageobjects.SwitchBackendPage;
 
 public class TestSwitchBackend extends SeleniumBaseClass{
-    private MockServerClient mockClient1;
-    private MockServerClient mockClient2;
-    private ClientAndServer mockServer1;
-    private ClientAndServer mockServer2;
+    private static MockServerClient mockClient1;
+    private static MockServerClient mockClient2;
+    private static ClientAndServer mockServer1;
+    private static ClientAndServer mockServer2;
 
 
     private static final String BASE_URL = "localhost";
@@ -40,8 +40,6 @@ public class TestSwitchBackend extends SeleniumBaseClass{
 
     @Test
     public void testSwitchBackend() throws Exception {
-        setUpMocks();
-
         // Open indexpage and verify that it is opened
         IndexPage indexPageObject = new IndexPage(null, driver, baseUrl);
         indexPageObject.loadPage();
@@ -74,26 +72,17 @@ public class TestSwitchBackend extends SeleniumBaseClass{
         switchBackendPage.removeInstanceNumber(1);
         assertEquals("switchBackendPage.presenceOfInstance returned true when it should have been false",
             false, switchBackendPage.presenceOfInstance(1));
-
-        tearDownMocks();
     }
 
-    private void tearDownMocks() {
-        mockServer1.stop();
-        mockServer2.stop();
-
-        mockClient1.stop();
-        mockClient2.stop();
-    }
-
-    private void setUpMocks() throws IOException {
+    @BeforeClass
+    public static void setUpMocks() throws IOException {
         mockServer1 = startClientAndServer(PORTSERVER1);
         mockServer2 = startClientAndServer(PORTSERVER2);
 
         mockClient1 = new MockServerClient(BASE_URL, PORTSERVER1);
         mockClient2 = new MockServerClient(BASE_URL, PORTSERVER2);
 
-        String informationResponse = this.getJSONStringFromFile(INFORMATION_RESPONSE_FILEPATH);
+        String informationResponse = getJSONStringFromFile(INFORMATION_RESPONSE_FILEPATH);
         mockClient2
             .when(
                 request()
@@ -114,7 +103,7 @@ public class TestSwitchBackend extends SeleniumBaseClass{
                     .withStatusCode(200)
                     .withBody(""));
 
-        String newInstanceSubscriptionResponse = this.getJSONStringFromFile(NEW_INSTANCE_SUBSCRIPTION_RESPONSE_FILEPATH);
+        String newInstanceSubscriptionResponse = getJSONStringFromFile(NEW_INSTANCE_SUBSCRIPTION_RESPONSE_FILEPATH);
         mockClient2
             .when(
                 request()
@@ -124,7 +113,7 @@ public class TestSwitchBackend extends SeleniumBaseClass{
                 response().withStatusCode(200)
                     .withBody(newInstanceSubscriptionResponse));
 
-        String defaultInstanceSubscriptionResponse = this.getJSONStringFromFile(DEFAULT_INSTANCE_SUBSCRIPTION_RESPONSE_FILEPATH);
+        String defaultInstanceSubscriptionResponse = getJSONStringFromFile(DEFAULT_INSTANCE_SUBSCRIPTION_RESPONSE_FILEPATH);
         mockClient1
             .when(
                 request()
@@ -134,5 +123,14 @@ public class TestSwitchBackend extends SeleniumBaseClass{
                 response()
                     .withStatusCode(200)
                     .withBody(defaultInstanceSubscriptionResponse));
+    }
+
+    @AfterClass
+    public static void tearDownMocks() {
+        mockServer1.stop();
+        mockServer2.stop();
+
+        mockClient1.stop();
+        mockClient2.stop();
     }
 }

--- a/src/functionaltest/java/com/ericsson/ei/frontend/exception/PropertiesNotLoadedException.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/exception/PropertiesNotLoadedException.java
@@ -1,0 +1,19 @@
+package com.ericsson.ei.frontend.exception;
+
+public class PropertiesNotLoadedException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public PropertiesNotLoadedException() {
+        super();
+    }
+
+    public PropertiesNotLoadedException(String message) {
+        super(message);
+    }
+
+    public PropertiesNotLoadedException(String message, Throwable e) {
+        super(message, e);
+    }
+
+}

--- a/src/functionaltest/resources/functional-test.properties
+++ b/src/functionaltest/resources/functional-test.properties
@@ -1,0 +1,2 @@
+test.selenium.firefox.BZip2File.linux = https://download.mozilla.org/?product=firefox-61.0.1-ssl&os=linux64&lang=en-GB
+test.selenium.firefox.BZip2File.linux.name = firefox-61.0.1.tar.bz2

--- a/src/functionaltest/resources/functional-test.properties
+++ b/src/functionaltest/resources/functional-test.properties
@@ -1,2 +1,1 @@
-test.selenium.firefox.BZip2File.linux = https://download.mozilla.org/?product=firefox-61.0.1-ssl&os=linux64&lang=en-GB
-test.selenium.firefox.BZip2File.linux.name = firefox-61.0.1.tar.bz2
+test.selenium.firefox.BZip2File.url.linux = https://ftp.mozilla.org/pub/firefox/releases/61.0.1/linux-x86_64/en-GB/firefox-61.0.1.tar.bz2


### PR DESCRIPTION
- Firefox could not run on Linux where firefox did not exist,
  this fix makes it possible for firefox to download binaries and
  install them for firefoxdriver.
- Fix minor issue with mockservers teardown.